### PR TITLE
feat(#15): Document Export (Markdown and HTML)

### DIFF
--- a/apps/web/src/lib/components/editor/EditorHeader.svelte
+++ b/apps/web/src/lib/components/editor/EditorHeader.svelte
@@ -23,6 +23,7 @@
   import Loader2 from '@lucide/svelte/icons/loader-2';
   import FileText from '@lucide/svelte/icons/file-text';
   import Code from '@lucide/svelte/icons/code';
+  import { toast } from 'svelte-sonner';
   import type { Snippet } from 'svelte';
 
   // --------------------------------------------------------------------------
@@ -137,13 +138,17 @@
 ${html}
 </body>
 </html>`;
-    downloadFile(fullHtml, `${title || 'document'}.html`, 'text/html');
+    const filename = `${title || 'document'}.html`;
+    downloadFile(fullHtml, filename, 'text/html');
+    toast.success(`Downloaded ${filename}`);
   }
 
   function handleExportMarkdown() {
     if (!onExportMarkdown) return;
     const markdown = onExportMarkdown();
-    downloadFile(markdown, `${title || 'document'}.md`, 'text/markdown');
+    const filename = `${title || 'document'}.md`;
+    downloadFile(markdown, filename, 'text/markdown');
+    toast.success(`Downloaded ${filename}`);
   }
 </script>
 


### PR DESCRIPTION
## Description

This PR enhances the existing document export functionality by adding toast notifications to provide user feedback when files are downloaded.

## Related Issue

Closes #15

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `style` -- Formatting, linting (no logic change)
- [ ] `test` -- Adding or updating tests
- [ ] `chore` -- Build, CI, tooling, dependencies
- [ ] `perf` -- Performance improvement

## Changes Made

- Added `svelte-sonner` toast import to EditorHeader component
- Added success toast notification when exporting to HTML (shows filename)
- Added success toast notification when exporting to Markdown (shows filename)

Note: The core export functionality was already implemented in a previous PR. This PR adds user feedback via toast notifications.

## How to Test

1. Checkout this branch
2. Run `pnpm dev`
3. Open a document
4. Click the Download button (dropdown) in the header
5. Select "HTML" - verify file downloads and toast appears: "Downloaded {title}.html"
6. Select "Markdown" - verify file downloads and toast appears: "Downloaded {title}.md"

## Verification Checklist

- [x] Code compiles / builds without errors or warnings.
- [x] All existing tests pass (34/34 tests pass).
- [x] Lint and format checks pass with zero violations.
- [x] The feature works as described in the Issue acceptance criteria.
- [x] No hardcoded secrets, API keys, or credentials in the code.
- [x] File headers and comments follow `docs/global-instructions.md` Section 3.
- [x] PR description links to the related Issue.

## Additional Notes

The export functionality already satisfied most acceptance criteria from Issue #15:
- [x] Export button visible in document toolbar/header
- [x] Dropdown menu shows "Download as Markdown" and "Download as HTML" options
- [x] Markdown export preserves all formatting
- [x] HTML export produces clean, styled output
- [x] Downloaded file uses document title as filename
- [x] Export works from local editor state (no server round-trip)

This PR adds the finishing touch of user feedback via toast notifications.

---

Sprint: Sprint 2